### PR TITLE
Allow specify percentiles in timer creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ target/
 .bloop/
 .metals/
 project/metals.sbt
+project/project/
 .idea/
 .vscode/

--- a/core/src/main/scala/com/ovoenergy/meters4s/Reporter.scala
+++ b/core/src/main/scala/com/ovoenergy/meters4s/Reporter.scala
@@ -50,7 +50,7 @@ trait Reporter[F[_]] {
     * @param tags tags associated with this timer
     * @return an effect that evaluates to a timer instance
     */
-  def timer(name: String, tags: Map[String, String] = Map.empty): F[Timer[F]]
+  def timer(name: String, tags: Map[String, String] = Map.empty, percentiles: Set[Double] = Set.empty): F[Timer[F]]
 
   /**
     * Create a gauge
@@ -230,11 +230,12 @@ private class MeterRegistryReporter[F[_]](
         }
       }
 
-  def timer(name: String, tags: Map[String, String]): F[Timer[F]] =
+  def timer(name: String, tags: Map[String, String], percentiles: Set[Double]): F[Timer[F]] =
     F.delay {
         micrometer.Timer
           .builder(metricName(name))
           .tags(effectiveTags(tags))
+          .publishPercentiles(percentiles.toSeq:_*)
           .register(mx)
       }
       .map { t =>


### PR DESCRIPTION
Allow specifying which percentile to publish for the timer.

I would like to have something as `case class Percentile(value: Double)` with a constructor that would validate the input (0...1) but because in this project we are not using specialized classes for `name` or `tag` I have opted to be consistent.

We may improve in a further major version.