### PR TITLE
Agg Gauge set and modify

### DIFF
--- a/core/src/test/scala/com/ovoenergy/meters4s/ReporterTest.scala
+++ b/core/src/test/scala/com/ovoenergy/meters4s/ReporterTest.scala
@@ -251,6 +251,27 @@ class ReporterTest(implicit ec: ExecutionContext) extends Specification {
   }
 
   "gauge" >> {
+
+    "set should set the gauge value" >> {
+      val registry = new SimpleMeterRegistry
+      val reporter = Reporter.fromRegistry[IO](registry).unsafeRunSync()
+
+      val testee = reporter.gauge("test.gauge")
+      testee.flatMap(_.set(10)).unsafeRunSync()
+
+      registry.find("test.gauge").gauge().value must_== 10
+    }
+
+    "modify should modify the gauge value" >> {
+      val registry = new SimpleMeterRegistry
+      val reporter = Reporter.fromRegistry[IO](registry).unsafeRunSync()
+
+      val testee = reporter.gauge("test.gauge", initialValue = 8)
+      testee.flatMap(_.modify(_ + 4)).unsafeRunSync()
+
+      registry.find("test.gauge").gauge().value must_== 12
+    }
+
     "increment should increment the gauge" >> {
       val registry = new SimpleMeterRegistry
       val reporter = Reporter.fromRegistry[IO](registry).unsafeRunSync()

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.0
+sbt.version=1.4.6


### PR DESCRIPTION
Allow the gauge to be set vith a value. It is very useful when you have to report a value from an external library, like the size of cache or similar.

The mofify method is the base for all the others.