### PR TITLE
Add support for distribution summaries

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.6")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")


### PR DESCRIPTION
Provides support for [Distribution Summaries](https://micrometer.io/docs/concepts#_distribution_summaries) (which are like timers, but do not record elapsed time).

There's one extra property called "baseUnits", and from Micrometer:

> Base units are part of the naming convention for some monitoring systems. Leaving it off and violating the naming convention has no adverse effect if you forget.

Notes:
* Couldn't find scalafmt 2.4.6 (the conf specifies 2.4.2 anyway)
* Both the Timer and DistributionSummary could be improved to provide more [histogram options](https://micrometer.io/docs/concepts#_histograms_and_percentiles), in particular publishPercentileHistogram ([example](https://micrometer.io/docs/registry/datadog#_through_dogstatsd_approach)) and serviceLevelObjectives. Decided against doing this here, as we don't particularly need this right now.