### PR TITLE
Wrap everything that calls getOrCreateMeter in blocking.

### DIFF
--- a/core/src/main/scala/com/ovoenergy/meters4s/Reporter.scala
+++ b/core/src/main/scala/com/ovoenergy/meters4s/Reporter.scala
@@ -309,7 +309,7 @@ private class MeterRegistryReporter[F[_]](
   def metricName(name: String): String = s"${config.prefix}${name}"
 
   def counter(name: String, tags: Map[String, String]): F[Counter[F]] =
-    F.delay {
+    F.blocking {
         micrometer.Counter
           .builder(metricName(name))
           .tags(effectiveTags(tags))
@@ -328,7 +328,7 @@ private class MeterRegistryReporter[F[_]](
       tags: Map[String, String],
       percentiles: Set[Double]
   ): F[Timer[F]] =
-    F.delay {
+    F.blocking {
         micrometer.Timer
           .builder(metricName(name))
           .tags(effectiveTags(tags))
@@ -364,7 +364,7 @@ private class MeterRegistryReporter[F[_]](
       initialValue: Int
   ): F[AtomicInteger] = F.delay(new AtomicInteger(initialValue)).flatTap {
     gauge =>
-      F.delay(
+      F.blocking(
         micrometer.Gauge
           .builder(
             name,
@@ -415,7 +415,7 @@ private class MeterRegistryReporter[F[_]](
       percentiles: Set[Double],
       baseUnit: Option[String]
   ): F[DistributionSummary[F]] =
-    F.delay {
+    F.blocking {
         val builder = micrometer.DistributionSummary
           .builder(metricName(name))
           .tags(effectiveTags(tags))


### PR DESCRIPTION
These calls can block on a lock here:
https://github.com/micrometer-metrics/micrometer/blob/54f89f40743937a5a78fb57eb0ddb6b2e6238be4/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java#L598

fixes #16